### PR TITLE
Re-format languages and proficiencies

### DIFF
--- a/public/javascript/character-creator.js
+++ b/public/javascript/character-creator.js
@@ -49,7 +49,7 @@ const stringFromArray = function (array) {
     for (let i = 0; i < array.length; i++) {
         arr.push(array[i].name);
     }
-    return arr.join(" ");
+    return arr.join(", ");
 }
 
 // choose x amount of random element from array - for choosing allowed # of proficiencies, and turning to string

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -19,6 +19,8 @@ const gte = (var1, var2) => { return var1 >=  var2 };
 //       return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
 //   }
 // });
+
+// takes string of proficiencies separated by spaces, turns it into an array, goes through each item in the array and removes 'skill-' previx, then if the remainder is longer than two words, it replaces the dash separating the words with a space, then joins items in array into a string separated by a comma and a space. 
 const format_prof = function (str) {
   let profArr = (str.split(" "));
   let newProfArr = [];

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -19,10 +19,24 @@ const gte = (var1, var2) => { return var1 >=  var2 };
 //       return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
 //   }
 // });
+const format_prof = function (str) {
+  let profArr = (str.split(" "));
+  let newProfArr = [];
+  for (let i = 0; i < profArr.length; i++) {
+    let prof = profArr[i].split('skill-');
+    if (prof.length > 1) {
+    	prof.splice(0,1);
+    }
+    prof = prof.toString().replace('-', ' ');
+    newProfArr.push(prof);
+  }
+  return newProfArr.join(', ');
+}
 
 
 //-- EXPORTS
 module.exports = {
   format_date,
-  eq, ne, lt, gt, lte, gte
+  eq, ne, lt, gt, lte, gte, 
+  format_prof
 }

--- a/views/partials/character-sheet-template.handlebars
+++ b/views/partials/character-sheet-template.handlebars
@@ -245,7 +245,7 @@
         </div> --}}
         <div class="otherprofs box textblock">
           <label for="otherprofs">Other Proficiencies and Languages</label>
-          <textarea name="otherprofs">{{languages}} {{proficiencies}}</textarea>
+          <textarea name="otherprofs">Languages: {{languages}} Proficiencies: {{format_prof proficiencies}}</textarea>
         </div>
       </section>
       {{!-- COLUMN 1 --> END --}}


### PR DESCRIPTION
Changes made: 
- in public/javascript/character-creator.js: 
  - changed the way the languages are joined as a string so that they display in character sheet separated by commas instead of just placed one after the other, making it more legible. 
- in views/partials/character-sheet-template.handlebars: 
  - changed display of languages and proficiencies to appear after respective labels for more legibility.
- in utils/helpers.js: 
  - created helper to separate proficiencies into more legible format: 
    - takes in string of proficiencies separated by spaces as a parameter
    - turns it into an array
    - loops through each item and removes 'skill-' prefix
    - if remaining proficiency name is longer than one word, it separates the words by replacing '-' with a space
    - joins the individual strings back into an array separated by a comma and space for greater legibility in character sheet.