### PR TITLE
Bug/format prof

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Our main challenge was working on the different files and connecting them to eac
 
 ## Where can we use this app?
 You can view the app at the sites below:
-- [Live URL](www.sheetshow.com) 
+- [Live URL](https://sheet-show.herokuapp.com/) 
 - [Github repo](https://github.com/barrantesc/The-Sheet-Show)
 
 ## What does it look like?

--- a/controllers/home-routes.js
+++ b/controllers/home-routes.js
@@ -142,7 +142,7 @@ router.get('/hero-card/:id', async (req, res) => {
         res.render('hero-card', {
             heros,
             username: req.session.username,
-            // session_userId: req.session.user_id,
+            session_user_id: req.session.user_id,
             loggedIn: req.session.loggedIn,
             
         })

--- a/views/character-sheet.handlebars
+++ b/views/character-sheet.handlebars
@@ -1,5 +1,11 @@
+<link rel="stylesheet" href="../css/character-sheet-template.css">
 
-<link rel="stylesheet" href="/css/character-sheet-template.css">
+<style>
+  .charsheet{
+      display: block;
+    }
+</style>
+
 <form class="charsheet">
   {{!-- Sheet Header --}}
   <header>
@@ -458,4 +464,4 @@
 {{!-- Ability to edit char sheet manually --}}
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-<script src="./js/character-sheet-template-blank.js"></script>
+<script src="./javascript/character-sheet-template.js"></script>

--- a/views/hero-card.handlebars
+++ b/views/hero-card.handlebars
@@ -1,6 +1,6 @@
 
 {{#each heros as |hero|}}
 
-    {{> hero-card-details }}
+    {{> hero-card-details session_user_id}}
 
 {{/each}}

--- a/views/partials/hero-card-details.handlebars
+++ b/views/partials/hero-card-details.handlebars
@@ -58,7 +58,9 @@
 
             {{!-- Background --}}
             <div class="hero-proficiencies">
-                <span class="proficiencies">{{format_prof proficiencies}}</span>
+                {{#if proficiencies}}
+                    <span class="proficiencies">{{format_prof proficiencies}}</span>
+                {{/if}}
             </div>
             </span>
 


### PR DESCRIPTION
## Fixed BUG where if proficiencies empty handlebars crashes when trying to use utility function `format_prof`

```html
 {{!-- Background --}}
<div class="hero-proficiencies">
    {{#if proficiencies}}
        <span class="proficiencies">{{format_prof proficiencies}}</span>
    {{/if}}
</div>
```